### PR TITLE
Initialize `interval_cur` so check works

### DIFF
--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -96,6 +96,7 @@ while True:
     try:
         amrline = rtlamr.stdout.readline().strip()
         flds = amrline.split(",")
+        interval_cur = None
 
         # proper IDM results have 66 fields
         if len(flds) == 66:


### PR DESCRIPTION
Checking a non-existent variable doesn't work, initialize it to `None` up front.