### PR TITLE
Use `rtlamr`'s built-in ID filter

### DIFF
--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -86,8 +86,14 @@ rtltcp = subprocess.Popen(
 time.sleep(10)
 
 # start the rtlamr program.
+rtlamr_cmd = [settings.RTLAMR, f"-msgtype={settings.MESSAGE_TYPES}", "-format=csv"]
+
+# Add ID filter if we have a list of IDs to watch
+if settings.WATCHED_METERS:
+    rtlamr_cmd += [f"-filterid={settings.WATCHED_METERS}"]
+
 rtlamr = subprocess.Popen(
-    [settings.RTLAMR, f"-msgtype={settings.MESSAGE_TYPES}", "-format=csv"],
+    rtlamr_cmd,
     stdout=subprocess.PIPE,
     universal_newlines=True,
 )
@@ -116,10 +122,6 @@ while True:
 
         # invalid message or unsupported message type
         else:
-            continue
-
-        # make sure the meter id is one we want
-        if settings.WATCHED_METERS and meter_id not in settings.WATCHED_METERS:
             continue
 
         # Process interval if message type supports it (IDM)

--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -4,11 +4,10 @@ import os
 import logging
 
 # List of the Meter IDs to watch
-# Use empty brackets to read all meters - []
-# List may contain only one entry - [12345678]
-# or multiple entries - [12345678, 98765432, 12340123]
-power_meters = os.environ["WATCHED_METERS"].split(",")
-WATCHED_METERS = [int(meter_id) for meter_id in power_meters if meter_id]
+# Use empty string to read all meters
+# List may contain only one entry - "12345678"
+# or multiple entries - "12345678,98765432,12340123"
+WATCHED_METERS = os.environ["WATCHED_METERS"]
 
 # List of message types to watch for
 # Must be provided as only specific types are supported right now


### PR DESCRIPTION
`rtlamr` has a native filter option for meter ID. Use that instead of listening for all messages and filtering them out by ID ourselves to improve performance.