### PR TITLE
Don't run rtl_tcp as a user

### DIFF
--- a/amr2mqtt/rootfs/etc/services.d/rtl_tcp/run
+++ b/amr2mqtt/rootfs/etc/services.d/rtl_tcp/run
@@ -6,5 +6,4 @@
 # ==============================================================================
 
 bashio::log.info 'Starting rtl_tcp daemon...'
-exec s6-setuidgid abc \
-    /usr/bin/rtl_tcp
+/usr/bin/rtl_tcp


### PR DESCRIPTION
Since `rtl_tcp` needs usb access, run it as root rather then as our created user.