### PR TITLE
Use `/ssl` for ca cert and not for client certs

### DIFF
--- a/amr2mqtt/rootfs/etc/cont-init.d/30-config.sh
+++ b/amr2mqtt/rootfs/etc/cont-init.d/30-config.sh
@@ -26,17 +26,17 @@ else
     fi
 fi
 if bashio::config.exists 'mqtt.cert'; then
-    if ! bashio::fs.file_exists "/ssl/$(bashio::config 'mqtt.cert')"; then
+    if ! bashio::fs.file_exists "$(bashio::config 'mqtt.cert')"; then
         bashio::log.fatal
         bashio::log.fatal "The file specified for 'mqtt.cert' does not exist!"
-        bashio::log.fatal "Ensure client certificate file exists in /ssl and correct path is provided."
+        bashio::log.fatal "Ensure client certificate file exists and full path is provided."
         bashio::log.fatal
         bashio::exit.nok
     fi
-    if ! bashio::fs.file_exists "/ssl/$(bashio::config 'mqtt.key')"; then
+    if ! bashio::fs.file_exists "$(bashio::config 'mqtt.key')"; then
         bashio::log.fatal
         bashio::log.fatal "The file specified for 'mqtt.key' does not exist!"
-        bashio::log.fatal "Ensure client certificate key file exists in /ssl and correct path is provided."
+        bashio::log.fatal "Ensure client certificate key file exists and full path is provided."
         bashio::log.fatal
         bashio::exit.nok
     fi

--- a/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
+++ b/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
@@ -47,7 +47,7 @@ if bashio::config.exists 'mqtt.base_topic'; then
 fi
 
 if ! bashio::config.is_empty 'mqtt.ca'; then
-    export "MQTT_CA=$(bashio::config 'mqtt.ca')"
+    export "MQTT_CA=/ssl/$(bashio::config 'mqtt.ca')"
     
     if ! bashio::config.is_empty 'mqtt.cert'; then
         export "MQTT_CERT=$(bashio::config 'mqtt.cert')"


### PR DESCRIPTION
Was not looking in `/ssl` for ca certificate. Client certificates need full path so users can put them in the addon internal `/data` folder if they wish.
