### PR TITLE
Missing port config option

### DIFF
--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -31,6 +31,7 @@ schema:
     - list(scm|idm)
   mqtt:
     host: str?
+    port: port?
     ca: str?
     cert: str?
     key: str?

--- a/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
+++ b/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
@@ -24,7 +24,7 @@ unset IFS
 bashio::log.debug "Setting MQTT details..."
 if ! bashio::config.is_empty 'mqtt.host'; then
     host=$(bashio::config 'mqtt.host')
-    port=$(bashio::config 'mqtt.port')
+    port=$(bashio::config 'mqtt.port' 1883)
     username=$(bashio::config 'mqtt.username')
     password=$(bashio::config 'mqtt.password')
 else


### PR DESCRIPTION
Missing `mqtt.port` from config options. Also default to `1883` if omitted.
