### PR TITLE
Keep connection to MQTT broker while running

### DIFF
--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -34,28 +34,15 @@ WH_MULTIPLIER = int(os.environ.get("WH_MULTIPLIER", 1000))
 #     READINGS_PER_HOUR = 4
 READINGS_PER_HOUR = int(os.environ.get("READINGS_PER_HOUR", 12))
 
-# Get server and auth settings
+# Get server, TLS and auth settings
 MQTT_HOST = os.environ.get("MQTT_HOST")
 MQTT_PORT = int(os.environ.get("MQTT_PORT"))
+MQTT_CA_CERT = os.environ.get("MQTT_CA")
+MQTT_CERTFILE = os.environ.get("MQTT_CERT")
+MQTT_KEYFILE = os.environ.get("MQTT_KEY")
+MQTT_USERNAME = os.environ.get("MQTT_USERNAME")
+MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD")
 MQTT_CLIENT_ID = os.environ.get("MQTT_CLIENT_ID")
-
-username = os.environ.get("MQTT_USERNAME")
-password = os.environ.get("MQTT_PASSWORD")
-if username and password:
-    MQTT_AUTH = {"username": username, "password": password}
-else:
-    MQTT_AUTH = None
-
-# If TLS in use, a CA file must be provided
-# Client Key+Cert can optionally be provided as well
-if os.environ.get("MQTT_CA"):
-    MQTT_TLS = {
-        "ca_certs": os.environ.get("MQTT_CA"),
-        "certfile": os.environ.get("MQTT_CERT"),
-        "keyfile": os.environ.get("MQTT_KEY"),
-    }
-else:
-    MQTT_TLS = None
 
 # Set the MQTT base topic with the user's prefix if provided
 MQTT_DEFAULT_BASE_TOPIC = "readings"


### PR DESCRIPTION
Instead of opening and closing a connection to the broker with each message, keep the connection open while the service is running. Also validate we can connect to the broker during config.