### PR TITLE
Change `wh_multiplier` to `reading_multiplier`

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -47,7 +47,7 @@ Example add-on configuration:
 
 TODO
 
-### Option: `wh_multiplier`
+### Option: `reading_multiplier`
 
 TODO
 

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -18,14 +18,15 @@ map:
   - ssl
 options:
   watched_meters: []
-  wh_multiplier: 1000
+  reading_multiplier: 1.0
   message_types:
     - scm
+    - idm
   mqtt: {}
 schema:
   watched_meters:
     - int
-  wh_multiplier: int(1,)
+  reading_multiplier: float(0,)?
   readings_per_hour: int(1,)?
   message_types:
     - list(scm|idm)

--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -123,7 +123,9 @@ while True:
             # take the last interval usage times 10 to get watt-hours,
             # then times 12 to get average usage in watts
             rate = (
-                interval_read_cur * settings.WH_MULTIPLIER * settings.READINGS_PER_HOUR
+                interval_read_cur
+                * settings.READING_MULTIPLIER
+                * settings.READINGS_PER_HOUR
             )
 
             logging.debug("Sending meter %s rate: %s", meter_id, rate)
@@ -136,7 +138,7 @@ while True:
             set_last_interval(meter_id, interval_cur)
 
         # Send current reading to MQTT
-        current_reading_in_kwh = (read_cur * settings.WH_MULTIPLIER) / 1000
+        current_reading_in_kwh = read_cur * settings.READING_MULTIPLIER
 
         logging.debug("Sending meter %s reading: %s", meter_id, current_reading_in_kwh)
         mqttc.publish(

--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -14,15 +14,15 @@ WATCHED_METERS = os.environ["WATCHED_METERS"]
 # See differences here: https://github.com/bemasher/rtlamr#message-types
 MESSAGE_TYPES = os.environ["MESSAGE_TYPES"]
 
-# multiplier to get reading to Watt Hours (Wh)
+# multiplier to get reading to desired units
 # examples:
-#   for meter providing readings in kWh
-#      MULTIPLIER = 1000
-#   for meter providing readings in kWh
-#   with 2 extra digits of precision
-#      MULTIPLIER = 10
+#   for meter providing readings in desired units currently
+#      MULTIPLIER = 1
+#   for meter providing readings with 2 extra digits of precision
+#        Ex. Hundreds of a kWh instead of just kWh
+#      MULTIPLIER = 0.01
 # MULTIPLIER needs to be a number
-WH_MULTIPLIER = int(os.environ.get("WH_MULTIPLIER", 1000))
+READING_MULTIPLIER = int(os.environ.get("READING_MULTIPLIER"))
 
 # number of IDM intervals per hour reported by the meter
 # examples:
@@ -32,7 +32,7 @@ WH_MULTIPLIER = int(os.environ.get("WH_MULTIPLIER", 1000))
 #   for meter providing readings every 15 minutes
 #   or 12 times every hour
 #     READINGS_PER_HOUR = 4
-READINGS_PER_HOUR = int(os.environ.get("READINGS_PER_HOUR", 12))
+READINGS_PER_HOUR = int(os.environ.get("READINGS_PER_HOUR"))
 
 # Get server, TLS and auth settings
 MQTT_HOST = os.environ.get("MQTT_HOST")

--- a/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
+++ b/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
@@ -12,8 +12,8 @@ declare password
 
 # --- LOAD BASIC SETTINGS ---
 bashio::log.debug "Loading basic settings..."
-export "WH_MULTIPLIER=$(bashio::config 'wh_multiplier')"
-export "READINGS_PER_HOUR=$(bashio::config 'readings_per_hour')"
+export "READING_MULTIPLIER=$(bashio::config 'reading_multiplier' 1)"
+export "READINGS_PER_HOUR=$(bashio::config 'readings_per_hour' 12)"
 
 IFS=","
 export "WATCHED_METERS=$(bashio::config 'watched_meters')"


### PR DESCRIPTION
`wh_multiplier` was specifically for the original author's use case. Where the IDM meter was reporting both interval and total consumption of electricity and they wanted the interval in Wh but the total in kWh. Since this add-on is designed to support other meter reading use cases as well, make the option more generic and just have it accept a multiplier to convert to the unit of choice.