### PR TITLE
Quiet `rtl_tcp` based on `log_level`

### DIFF
--- a/amr2mqtt/rootfs/etc/services.d/rtl_tcp/run
+++ b/amr2mqtt/rootfs/etc/services.d/rtl_tcp/run
@@ -6,4 +6,10 @@
 # ==============================================================================
 
 bashio::log.info 'Starting rtl_tcp daemon...'
-/usr/bin/rtl_tcp
+# If log level is set higher then notice, suppress all output from rtl_tcp
+case "$(bashio::config 'log_level')" in \
+    warning)    ;& \
+    error)      ;& \
+    fatal)      /usr/bin/rtl_tcp > /dev/null 2>&1 ;; \
+    *)          /usr/bin/rtl_tcp ;; \
+esac;


### PR DESCRIPTION
If log level is above `notice`, suppress all of `rtl_tcp`'s output. Otherwise let it through to the log.
