### PR TITLE
Change config to be based around meters

### DIFF
--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -17,19 +17,16 @@ services:
 map:
   - ssl
 options:
-  watched_meters: []
-  reading_multiplier: 1.0
-  message_types:
-    - scm
-    - idm
+  meters: []
   mqtt: {}
 schema:
-  watched_meters:
-    - int
-  reading_multiplier: float(0,)?
-  readings_per_hour: int(1,)?
-  message_types:
-    - list(idm|r900|scm|scm+)
+  meters:
+    - id: int
+      protocol: list(idm|netidm|r900|scm|scm+)
+      name: str?
+      type: list(gas|water|electric)?
+      reading_multiplier: float(0,)?
+      reading_unit_of_measurement: str?
   mqtt:
     host: str?
     port: port?

--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 """
-Runs rtlamr to watch for broadcasts from power meter. If meter id
-is in the list, usage is sent to 'readings/{meter id}/meter_reading'
-topic on the MQTT broker specified in settings.
-
-WATCHED_METERS = A Python list indicating those meter IDs to record and post.
-MQTT_HOST = String containing the MQTT server address.
-MQTT_PORT = An int containing the port the MQTT server is active on.
+Runs rtlamr to watch for broadcasts from power meter(s). Passings readings
+found to MQTT at topic `amr2mqtt/{meter_ID}`. If meter ID
+is a watched one, processes its reading using settings first.
 
 """
 import logging
@@ -14,6 +10,7 @@ import subprocess
 import signal
 import sys
 import time
+import json
 import paho.mqtt.client as mqtt
 import settings
 
@@ -27,144 +24,143 @@ def shutdown(**_):
     sys.exit(0)
 
 
-def get_last_interval(meter_id):  # pylint: disable=redefined-outer-name
-    """Get last interval."""
-    return last_reading.get(meter_id, (None))
+def adjust_reading(m_id, reading, consumption_field, interval_field=None):
+    """Convert consumption and interval data using configured multiplier."""
+    if m_id in settings.METERS:
+        config = settings.METERS[m_id]
+        multiplier = config.get("reading_multiplier", 1)
+        reading["Consumption"] = reading[consumption_field] * multiplier
+
+        if interval_field:
+            reading["DifferentialConsumptionIntervals"] = [
+                interval * multiplier for interval in reading[interval_field]
+            ]
 
 
-def set_last_interval(meter_id, interval_id):  # pylint: disable=redefined-outer-name
-    """Set last interval."""
-    last_reading[meter_id] = interval_id
+def start_rtlamr():
+    """Start rtlamr program."""
+    rtlamr_cmd = [
+        settings.RTLAMR,
+        f"-msg_type={settings.WATCHED_PROTOCOLS}",
+        "-format=json",
+    ]
+
+    # Add ID filter if we have a list of IDs to watch
+    if settings.WATCHED_PROTOCOLS != "all":
+        rtlamr_cmd += [f"-filterid={settings.WATCHED_METERS}"]
+
+    return subprocess.Popen(
+        rtlamr_cmd,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+
+def create_mqtt_client():
+    """Create MQTT client with TLS and auth if necessary."""
+    client = mqtt.Client(client_id=settings.MQTT_CLIENT_ID)
+
+    if settings.MQTT_CA_CERT:
+        client.tls_set(
+            ca_certs=settings.MQTT_CA_CERT,
+            certfile=settings.MQTT_CERTFILE,
+            keyfile=settings.MQTT_KEYFILE,
+        )
+
+    if settings.MQTT_USERNAME:
+        client.username_pw_set(
+            settings.MQTT_USERNAME,
+            password=settings.MQTT_PASSWORD,
+        )
+
+    client.connect(
+        settings.MQTT_HOST,
+        port=settings.MQTT_PORT,
+        keepalive=60,
+    )
+    return client
+
+
+def main_loop():
+    """Loop and process messages from rtlamr."""
+    mqttc.loop_start()
+    while True:
+        try:
+            amr_line = rtlamr.stdout.readline().strip()
+            amr_dict = json.load(amr_line)
+
+            # Must have `message` or we ignore
+            if "Message" not in amr_dict:
+                continue
+
+            amr_message = amr_dict["Message"]
+            fields_count = len(amr_message.values())
+
+            # IDM results have 17 fields
+            if fields_count == 17:
+                msg_type = "idm"
+                meter_id = amr_message["ERTSerialNumber"]
+                adjust_reading(
+                    meter_id,
+                    amr_message,
+                    "LastConsumptionCount",
+                    "DifferentialConsumptionIntervals",
+                )
+
+            # NetIDM results have 16 fields
+            elif fields_count == 16:
+                msg_type = "netidm"
+                meter_id = amr_message["ERTSerialNumber"]
+                adjust_reading(
+                    meter_id,
+                    amr_message,
+                    "LastConsumptionNet",
+                    "DifferentialConsumptionIntervals",
+                )
+
+            # R900 results have 9 fields
+            elif fields_count == 9:
+                msg_type = "r900"
+                meter_id = amr_message["ID"]
+                adjust_reading(meter_id, amr_message, "Consumption")
+
+            # SCM results have 6 fields
+            elif fields_count == 6:
+                msg_type = "scm"
+                meter_id = amr_message["ID"]
+                adjust_reading(meter_id, amr_message, "Consumption")
+
+            # SCM+ results have 7 fields
+            elif fields_count == 7:
+                msg_type = "scm+"
+                meter_id = amr_message["EndpointID"]
+                adjust_reading(meter_id, amr_message, "Consumption")
+
+            # invalid message or unsupported message type
+            else:
+                continue
+
+            json_message = json.dumps(amr_message)
+            logging.debug(
+                "Meter: %s, MsgType: %s, Reading: %s",
+                meter_id,
+                msg_type,
+                json_message,
+            )
+            mqttc.publish(
+                f"{settings.MQTT_BASE_TOPIC}/{meter_id}",
+                json_message,
+            )
+
+        except Exception as ex:  # pylint: disable=broad-except
+            logging.debug("Exception squashed! %s: %s", ex.__class__.__name__, ex)
+            time.sleep(2)
 
 
 # Register signals we listen for
 signal.signal(signal.SIGTERM, shutdown)
 signal.signal(signal.SIGINT, shutdown)
 
-# stores last interval id to avoid duplication, includes getter and setter
-last_reading = {}
-
-# Set up logging
-logging.basicConfig()
-logging.getLogger().setLevel(settings.LOG_LEVEL)
-
-# start the rtlamr program.
-rtlamr_cmd = [
-    settings.RTLAMR,
-    f"-msgtype={settings.MESSAGE_TYPES}",
-    "-format=csv",
-]
-
-# Add ID filter if we have a list of IDs to watch
-if settings.WATCHED_METERS:
-    rtlamr_cmd += [f"-filterid={settings.WATCHED_METERS}"]
-
-rtlamr = subprocess.Popen(
-    rtlamr_cmd,
-    stdout=subprocess.PIPE,
-    universal_newlines=True,
-)
-
-# Create MQTT client and add TLS and auth if necessary
-mqttc = mqtt.Client(client_id=settings.MQTT_CLIENT_ID)
-
-if settings.MQTT_CA_CERT:
-    mqttc.tls_set(
-        ca_certs=settings.MQTT_CA_CERT,
-        certfile=settings.MQTT_CERTFILE,
-        keyfile=settings.MQTT_KEYFILE,
-    )
-
-if settings.MQTT_USERNAME:
-    mqttc.username_pw_set(
-        settings.MQTT_USERNAME,
-        password=settings.MQTT_PASSWORD,
-    )
-
-mqttc.connect(
-    settings.MQTT_HOST,
-    port=settings.MQTT_PORT,
-    keepalive=60,
-)
-
-mqttc.loop_start()
-while True:
-    try:
-        amrline = rtlamr.stdout.readline().strip()
-        flds = amrline.split(",")
-        interval_cur = None
-
-        # proper IDM results have 66 fields
-        if len(flds) == 66:
-            # get some required info: meter ID, current meter reading,
-            # current interval id, most recent interval usage
-            meter_id = int(flds[9])
-            read_cur = int(flds[15])
-            interval_cur = int(flds[10])
-            interval_read_cur = int(flds[16])
-            msgtype = "IDM"
-
-        # proper SCM results have 9 fields
-        elif len(flds) == 9:
-            # get some required info: meter ID, current meter reading,
-            meter_id = int(flds[3])
-            read_cur = int(flds[7])
-            msgtype = "SCM"
-
-        # proper SCM+ results have 10 fields
-        elif len(flds) == 10:
-            # get some required info: meter ID, current meter reading,
-            meter_id = int(flds[6])
-            read_cur = int(flds[7])
-            msgtype = "SCM+"
-
-        # proper R900 results have 11 fields
-        elif len(flds) == 11:
-            # get some required info: meter ID, current meter reading,
-            meter_id = int(flds[3])
-            read_cur = int(flds[7])
-            msgtype = "R900"
-
-        # invalid message or unsupported message type
-        else:
-            continue
-
-        # Process interval if message type supports it (IDM)
-        if interval_cur:
-            # skip if interval is the same as last time we sent to MQTT
-            if interval_cur == get_last_interval(meter_id):
-                continue
-
-            current_interval = interval_read_cur * settings.READING_MULTIPLIER
-
-            logging.debug(
-                "Meter: %s, MsgType: %s, Rate: %s",
-                meter_id,
-                msgtype,
-                current_interval,
-            )
-            mqttc.publish(
-                f"{settings.MQTT_BASE_TOPIC}/{meter_id}/interval_reading",
-                str(current_interval),
-            )
-
-            # store interval ID to avoid duplicating data
-            set_last_interval(meter_id, interval_cur)
-
-        # Send current reading to MQTT
-        current_reading = read_cur * settings.READING_MULTIPLIER
-
-        logging.debug(
-            "Meter: %s, MsgType: %s, Reading: %s",
-            meter_id,
-            msgtype,
-            current_reading,
-        )
-        mqttc.publish(
-            f"{settings.MQTT_BASE_TOPIC}/{meter_id}/meter_reading",
-            str(current_reading),
-        )
-
-    except Exception as ex:  # pylint: disable=broad-except
-        logging.debug("Exception squashed! %s: %s", ex.__class__.__name__, ex)
-        time.sleep(2)
+rtlamr = start_rtlamr()
+mqttc = create_mqtt_client()
+main_loop()

--- a/amr2mqtt/rootfs/etc/cont-init.d/30-config.sh
+++ b/amr2mqtt/rootfs/etc/cont-init.d/30-config.sh
@@ -56,6 +56,22 @@ if ! bashio::config.exists 'mqtt.username'; then
     fi
 fi
 
+# --- ENSURE NO DUPLICATE IDS IN METERS ---
+ids=''
+for var in $(bashio::config 'meters|keys'); do
+    id=$(bashio::config "meters[${var}].id")
+    ids="${ids} ${id}"
+done
+uniq_ids=$(ids | tr ' ' '\n' | awk '!arr[$1]++' | tr '\n' ' ' | xargs)
+
+if [ "${ids}" != "${uniq_ids}" ]; then
+    bashio::log.fatal
+    bashio::log.fatal "'meters' has two entries with the same ID!"
+    bashio::log.fatal "Cannot have duplicate IDs in the list of meters to watch."
+    bashio::log.fatal
+    bashio::exit.nok
+fi
+
 # --- ENSURE MQTT BROKER IS REACHABLE ---
 if ! bashio::config.is_empty 'mqtt.host'; then
     host=$(bashio::config 'mqtt.host')

--- a/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
+++ b/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
@@ -9,18 +9,6 @@ declare host
 declare port
 declare username
 declare password
-declare meters
-declare msg_types
-
-# --- LOAD BASIC SETTINGS ---
-bashio::log.debug "Loading basic settings..."
-export "READING_MULTIPLIER=$(bashio::config 'reading_multiplier' 1)"
-
-meters=$(bashio::config 'watched_meters')
-export "WATCHED_METERS=${meters//$'\n'/,}"
-
-msg_types=$(bashio::config 'message_types')
-export "MESSAGE_TYPES=${msg_types//$'\n'/,}"
 
 # --- LOAD MQTT SETTINGS ---
 bashio::log.debug "Setting MQTT details..."


### PR DESCRIPTION
Complete re-write of config. Realized it makes much more sense to base it entirely around the meters you want to watch rather then top-level settings. This also sets us up to do MQTT discovery with Home Assistant by creating the meters as devices.
