### PR TITLE
Fix docs and add HA discovery options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ You could also [open an issue here][issue] on GitHub.
 
 The original setup of this repository is by [Mike Degatano][mdegat01].
 
-The amridm2mqtt service this was built off of was created by [ragingcomputer][ragingcomputer].
-
 For a full list of all authors and contributors,
 check [the contributor's page][contributors].
 

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -36,5 +36,7 @@ schema:
     username: str?
     password: password?
     client_id: str?
-    base_topic: str?
+    base_topic: match(^[^+#]{1,65535}$)?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  home_assistant_discovery_enabled: bool?
+  home_assistant_discovery_prefix: match(^[^+#]{1,65535}$)?

--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -140,6 +140,10 @@ def main_loop():
             else:
                 continue
 
+            # If in debugging mode, add the protocol to the message
+            if settings.WATCHED_PROTOCOLS == "all":
+                amr_message["Protocol"] = msg_type
+
             json_message = json.dumps(amr_message)
             logging.debug(
                 "Meter: %s, MsgType: %s, Reading: %s",


### PR DESCRIPTION
Fix docs to account for all the new `watched_meters` options. Also add the new ha discovery options in config.
