### PR TITLE
Add support for HA MQTT discovery

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -133,7 +133,7 @@ Name for the meter. Only used in discovery messages.
 
 #### Sub-option: `type`
 
-Type of meter. must be one of the following: `gas`, `water`, or `electric`. Only
+Type of meter. must be one of the following: `gas`, `water`, or `energy`. Only
 used in discovery messages.
 
 #### Sub-option: `reading_multiplier`

--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -59,6 +59,9 @@ ARG BUILD_REF
 ARG BUILD_REPOSITORY
 ARG BUILD_VERSION
 
+# Set version as env for use in scripts
+ENV BUILD_VERSION=${BUILD_VERSION}
+
 # Labels
 LABEL \
     io.hass.name="${BUILD_NAME}" \

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -24,7 +24,7 @@ schema:
     - id: int
       protocol: list(idm|netidm|r900|scm|scm+)
       name: str?
-      type: list(gas|water|electric)?
+      type: list(gas|water|energy)?
       reading_multiplier: float(0,)?
       reading_unit_of_measurement: str?
   mqtt:

--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -36,10 +36,16 @@ MQTT_USERNAME = os.environ.get("MQTT_USERNAME")
 MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD")
 MQTT_CLIENT_ID = os.environ.get("MQTT_CLIENT_ID")
 
+# Get discovery info
+SW_VERSION = os.environ.get("BUILD_VERSION")
+HA_DISCOVERY_DISABLED = bool(os.environ.get("HA_DISCOVERY_DISABLED"))
+discovery_topic = os.environ.get("HA_DISCOVERY_TOPIC")
+HA_DISCOVERY_TOPIC = discovery_topic if bool(discovery_topic) else "homeassistant"
+
 # Set the MQTT base topic
-MQTT_DEFAULT_BASE_TOPIC = "amr2mqtt"
-if os.environ.get("MQTT_BASE_TOPIC"):
-    MQTT_BASE_TOPIC = os.environ.get("MQTT_BASE_TOPIC")
+base_topic = os.environ.get("MQTT_BASE_TOPIC")
+MQTT_BASE_TOPIC = base_topic if bool(base_topic) else "amr2mqtt"
+MQTT_AVAILABILTY_TOPIC = f"{MQTT_BASE_TOPIC}/bridge/state"
 
 # Set up logging
 EV_TO_LOG_LEVEL = {

--- a/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
+++ b/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
@@ -45,6 +45,13 @@ if ! bashio::config.is_empty 'mqtt.ca'; then
     fi
 fi
 
+# --- SET DISCOVERY SETTINGS ---
+if bashio::config.false 'home_assistant_discovery_enabled'; then
+    export "HA_DISCOVERY_DISABLED=true"
+elif bashio::config.exists 'home_assistant_discovery_prefix'; then
+    export "HA_DISCOVERY_TOPIC=$(bashio::config 'home_assistant_discovery_prefix')"
+fi
+
 # --- SET LOG LEVEL ---
 case "$(bashio::config 'log_level')" in \
     trace)      ;& \


### PR DESCRIPTION
On startup, send discovery messages for each watched meter to create sensors and devices in HA.