### PR TITLE
Change reading multiplier to reading decimals

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -136,15 +136,16 @@ Name for the meter. Only used in discovery messages.
 Type of meter. must be one of the following: `gas`, `water`, or `energy`. Only
 used in discovery messages.
 
-#### Sub-option: `reading_multiplier`
+#### Sub-option: `consumption_decimals`
 
-Used to convert the consumption number to the unit of your choice. Consumption
-numbers are whole numbers only so they may be in a weird unit, like hundredths
-of a kWh. Readings will be multiplied by this number before being reported to
-MQTT so you can convert to the unit you actually see on your bill.
+Meters can only report consumption in whole numbers and as a result they are
+generally in an undesirable unit, like hundredsth of a kWh. Use this to convert
+to a preferred unit by saying how many of the digits should be a decimal. Consumption
+values in readings will be multiplied by `10^-<consumption_decimals>` before being
+reported to MQTT so you can convert to the unit you actually see on your bill.
 
-**Note:** If your meter uses `idm` or `netidm` then the consumption value for
-each interval will also be multiplied by this number.
+**Note:** If your meter uses `idm` or `netidm` then the this formula will be used
+to convert the consumption value for each interval as well.
 
 #### Sub-option: `reading_unit_of_measurement`
 

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -25,7 +25,7 @@ schema:
       protocol: list(idm|netidm|r900|scm|scm+)
       name: str?
       type: list(gas|water|energy)?
-      reading_multiplier: float(0,)?
+      reading_decimals: int(0,)?
       reading_unit_of_measurement: str?
   mqtt:
     host: str?

--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -281,15 +281,17 @@ def send_discovery_messages():
 def adjust_reading(meter_id, reading, consumption_field, interval_field=None):
     """Convert consumption and interval data using configured multiplier."""
     if meter_id in settings.METERS:
-        multiplier = settings.METERS[meter_id].get("reading_multiplier", 1)
+        decimals = settings.METERS[meter_id].get("consumption_decimals", 0)
     else:
-        multiplier = 1
+        decimals = 0
 
-    reading["Consumption"] = reading[consumption_field] * multiplier
+    multiplier = 10 ** (-1 * decimals)
+    reading["Consumption"] = round(reading[consumption_field] * multiplier, decimals)
 
     if interval_field:
         reading["DifferentialConsumptionIntervals"] = [
-            interval * multiplier for interval in reading[interval_field]
+            round(interval * multiplier, decimals)
+            for interval in reading[interval_field]
         ]
 
 


### PR DESCRIPTION
Change from using a straight multiplier to a number of decimals. This limits the conversion options but prevents ugly conversions with floats.