### PR TITLE
Change to multiplier and precision config options

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -103,8 +103,8 @@ watched_meters:
     protocol: scm
     name: My gas meter
     type: gas
-    reading_multiplier: 0.01
-    reading_unit_of_measurement: ccf
+    multiplier: 0.01
+    unit_of_measurement: ccf
 mqtt:
   host: 127.0.0.1
   port: 1883
@@ -136,18 +136,26 @@ Name for the meter. Only used in discovery messages.
 Type of meter. must be one of the following: `gas`, `water`, or `energy`. Only
 used in discovery messages.
 
-#### Sub-option: `consumption_decimals`
+#### Sub-option: `multiplier`
 
 Meters can only report consumption in whole numbers and as a result they are
 generally in an undesirable unit, like hundredsth of a kWh. Use this to convert
-to a preferred unit by saying how many of the digits should be a decimal. Consumption
-values in readings will be multiplied by `10^-<consumption_decimals>` before being
-reported to MQTT so you can convert to the unit you actually see on your bill.
+the consumption value reported by your meter to your preferred unit of measurement.
 
-**Note:** If your meter uses `idm` or `netidm` then the this formula will be used
-to convert the consumption value for each interval as well.
+Examples:
 
-#### Sub-option: `reading_unit_of_measurement`
+- Consumption values in hundredsth of a kWh and you want kWh: set to `0.01`
+- Consumption values in ccf and you want cubic meters: set to `2.83168466`
+
+**Note:** If your meter uses `idm` or `netidm` then this multiplier will also be
+used to convert the consumption value for each interval.
+
+#### Sub-option: `precision`
+
+Reported consumption values will be rounded to this many decimal places after the
+multiplier is applied. If omitted, result will not be rounded.
+
+#### Sub-option: `unit_of_measurement`
 
 Unit of measurement for the consumption value. Only used in discovery messages.
 

--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
         ca-certificates=20210119 \
         librtlsdr-dev=0.6.0-3 \
         python3-paho-mqtt=1.5.1-1 \
+        python3-dateutil=2.8.1-6 \
         rtl-sdr=0.6.0-3 \
         ; \
     update-ca-certificates; \

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -25,8 +25,9 @@ schema:
       protocol: list(idm|netidm|r900|scm|scm+)
       name: str?
       type: list(gas|water|energy)?
-      consumption_decimals: int(0,)?
-      reading_unit_of_measurement: str?
+      multiplier: float(0,)?
+      precision: int(0,)?
+      unit_of_measurement: str?
   mqtt:
     host: str?
     port: port?

--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -16,8 +16,8 @@ def make_meters_map(meters, meter):
 # Pull in watched meters data
 # If not empty, pull out IDs/protocols to watch
 # If empty then we're in discovery mode
-config_options = open("/data/options.json")
-meters_config = json.load(config_options)["meters"]
+with open("/data/options.json", encoding="utf-8") as config_options:
+    meters_config = json.load(config_options)["meters"]
 
 if bool(meters_config):
     METERS = functools.reduce(make_meters_map, meters_config, {})


### PR DESCRIPTION
Need both multiplier and precision options in config to convert unit and keep precision in check from float issues.

Also took added `state_class` to discovery message for consumption sensors so they quality for Long-Term Statistics. For IDM interval consumption we're now using `TransmitTimeOffset` to calculate `last_reset` which I'm not 100% sure about but will test.

Besides that some refactoring into constants.