### PR TITLE
Bump addon debian base to `5.2.3`

### DIFF
--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
     rm /tmp/rtlamr.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.2.2
+FROM ${BUILD_FROM}:5.2.3
 
 RUN set -eux; \
     apt-get update; \


### PR DESCRIPTION
Bump addon debian base from `5.2.2` to [5.2.3](https://github.com/hassio-addons/addon-debian-base/releases/tag/v5.2.3)
