### PR TITLE
Cleanup discovery messages

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -131,11 +131,6 @@ Protocol the meter uses for its readings. Must be one of the following: `idm`,
 
 Name for the meter. Only used in discovery messages.
 
-#### Sub-option: `type`
-
-Type of meter. must be one of the following: `gas`, `water`, or `energy`. Only
-used in discovery messages.
-
 #### Sub-option: `multiplier`
 
 Meters can only report consumption in whole numbers and as a result they are
@@ -155,9 +150,22 @@ used to convert the consumption value for each interval.
 Reported consumption values will be rounded to this many decimal places after the
 multiplier is applied. If omitted, result will not be rounded.
 
+#### Sub-option: `type`
+
+Type of meter. must be one of the following: `gas`, `water`, or `energy`. Only
+used in discovery messages.
+
 #### Sub-option: `unit_of_measurement`
 
 Unit of measurement for the consumption value. Only used in discovery messages.
+
+#### Sub-option: `manufacturer`
+
+Manufacturer of the meter. Only used in discovery messages.
+
+#### Sub-option: `model`
+
+Model of the meter. Only used in discovery messages.
 
 ### Option: `mqtt.host`
 

--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -60,8 +60,9 @@ ARG BUILD_REF
 ARG BUILD_REPOSITORY
 ARG BUILD_VERSION
 
-# Set version as env for use in scripts
+# Set name & version as env for use in scripts
 ENV BUILD_VERSION=${BUILD_VERSION}
+ENV BUILD_NAME=${BUILD_NAME}
 
 # Labels
 LABEL \

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -28,6 +28,8 @@ schema:
       multiplier: float(0,)?
       precision: int(0,)?
       unit_of_measurement: str?
+      manufacturer: str?
+      model: str?
   mqtt:
     host: str?
     port: port?

--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -38,6 +38,7 @@ MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD")
 MQTT_CLIENT_ID = os.environ.get("MQTT_CLIENT_ID")
 
 # Get discovery info
+VIA_DEVICE = os.environ.get("BUILD_NAME")
 SW_VERSION = os.environ.get("BUILD_VERSION")
 HA_DISCOVERY_DISABLED = bool(os.environ.get("HA_DISCOVERY_DISABLED"))
 discovery_topic = os.environ.get("HA_DISCOVERY_TOPIC")


### PR DESCRIPTION
Flesh out discovery messages a bit more by adding options for `manufacturer` and `model`. Also set `entity_category` to diagnostic for all the non-consumption sensors and add `via_device` as the addon's name.
