### PR TITLE
Add option for `last_seen`

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -212,6 +212,12 @@ Client ID to use when connecting to the MQTT broker.
 By default, the topics of all MQTT messages begins with `amr2mqtt/{meter_ID}`.
 If you set this option then the topics will begin with `{mqtt.base_topic}/{meter_id}`.
 
+### Option: `last_seen`
+
+Add `last_seen` field to each message with the current time in the specified format.
+Options are: `ISO_8601`, `ISO_8601_local`, and `epoch`. Disabled if omitted. Useful
+for detecting issues when meter normally reports in on a consistent interval.
+
 ### Option: `home_assistant_discovery_enabled`
 
 Set to `false` to disable the add-on from sending discovery messages for the

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -43,3 +43,4 @@ schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   home_assistant_discovery_enabled: bool?
   home_assistant_discovery_prefix: match(^[^+#]{1,65535}$)?
+  last_seen: list(ISO_8601|ISO_8601_local|epoch)?

--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -49,6 +49,10 @@ base_topic = os.environ.get("MQTT_BASE_TOPIC")
 MQTT_BASE_TOPIC = base_topic if bool(base_topic) else "amr2mqtt"
 MQTT_AVAILABILTY_TOPIC = f"{MQTT_BASE_TOPIC}/bridge/state"
 
+# Using last seen
+LAST_SEEN_FORMAT = os.environ.get("LAST_SEEN")
+LAST_SEEN_ENABLED = LAST_SEEN_FORMAT != "disable"
+
 # Set up logging
 EV_TO_LOG_LEVEL = {
     "DEBUG": logging.DEBUG,

--- a/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
+++ b/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
@@ -52,6 +52,9 @@ elif bashio::config.exists 'home_assistant_discovery_prefix'; then
     export "HA_DISCOVERY_TOPIC=$(bashio::config 'home_assistant_discovery_prefix')"
 fi
 
+# --- OTHER SETTINGS ---
+export "LAST_SEEN=$(bashio::config 'last_seen' 'disable')"
+
 # --- SET LOG LEVEL ---
 case "$(bashio::config 'log_level')" in \
     trace)      ;& \


### PR DESCRIPTION
Add option to set `last_seen` attribute on sensors so users can watch for reporting gaps and alert.

Maybe its just me but my system seems to lose connection to its antenna sometimes. An alert will help me fix those issues quickly and also learn more about when it happens so I can try and figure out why.
