### PR TITLE
Bump hassio-addons/debian-base to `5.3.1`

### DIFF
--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -26,7 +26,8 @@ RUN set -eux; \
     rm /tmp/rtlamr.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.3.1
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
 
 RUN set -eux; \
     apt-get update; \

--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
     rm /tmp/rtlamr.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.2.3
+FROM ${BUILD_FROM}:5.3.1
 
 RUN set -eux; \
     apt-get update; \

--- a/amr2mqtt/build.yaml
+++ b/amr2mqtt/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/debian-base/amd64
-  armhf: ghcr.io/hassio-addons/debian-base/armhf
-  armv7: ghcr.io/hassio-addons/debian-base/armv7
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:5.3.1
+  armhf: ghcr.io/hassio-addons/debian-base/armhf:5.3.1
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:5.3.1
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:5.3.1


### PR DESCRIPTION
Bump hassio-addons/debian-base from `5.2.3` to [5.3.1](https://github.com/hassio-addons/addon-debian-base/releases/tag/v5.3.1)
