### PR TITLE
Allow 8 fields for R900 messages

### DIFF
--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -413,8 +413,9 @@ def main_loop():
                     idm_interval=idm_intervals[meter_id],
                 )
 
-            # R900 results have 9 fields
-            elif fields_count == 9:
+            # R900 results have 9 fields according to docs. But user reports
+            # suggest 8. Accept both since I don't have an R900 to test
+            elif fields_count in [8, 9]:
                 msg_type = "r900"
                 meter_id = str(amr_message[ID_FIELD])
                 adjust_reading(


### PR DESCRIPTION
# Proposed Changes

According to user reports, r900 results can have only 8 fields. This doesn't match the [rtlamr docs](https://github.com/bemasher/rtlamr/wiki/Protocol#r900-consumption-message) which is confusing. I am not an expert on this and don't have an r900 meter to test with so changing it say results with 8 or 9 messages are r900 to fix the bug.

## Related Issues

Fixes #60 
