### PR TITLE
Add symbol length option for rtlamr

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -228,6 +228,15 @@ watched meters.
 Defaults to `homeassistant`. Set if you use a custom MQTT discovery prefix in
 Home Assistant.
 
+### Option: `rtlamr_symbol_length`
+
+Sets symbollength in the rtlamr command used internally. If you are having issues
+with high CPU usage, try lowering this number. Your goal should be to set it as
+low as possible while still seeing results from your meter(s).
+
+Valid values are: 8, 32, 40, 48, 56, 64, 72, 80, 88, 96. Default is 72. See [here][rtlamr-configuration]
+for more information on rtlamr and this option.
+
 ## Home Assistant
 
 If you enable discovery then on start-up this add-on will send MQTT messages telling
@@ -349,5 +358,6 @@ SOFTWARE.
 [reddit-ll-issue]: https://www.reddit.com/r/RTLSDR/comments/bjc4mk/tweakstips_for_reading_meters_with_rtlamr/em8vnwn/
 [releases]: https://github.com/mdegat01/addon-amr2mqtt/releases
 [rtl-sdr-dongle]: https://www.amazon.com/s?k=RTL2832U
+[rtlamr-configuration]: https://github.com/bemasher/rtlamr/wiki/Configuration
 [rtlamr-protocols]: https://github.com/bemasher/rtlamr/wiki/Protocol
 [semver]: http://semver.org/spec/v2.0.0

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -45,3 +45,4 @@ schema:
   home_assistant_discovery_enabled: bool?
   home_assistant_discovery_prefix: match(^[^+#]{1,65535}$)?
   last_seen: list(ISO_8601|ISO_8601_local|epoch)?
+  rtlamr_symbol_length: list(8|32|40|48|56|64|72|80|88|96)?

--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -109,6 +109,7 @@ def start_rtlamr():
         settings.RTLAMR,
         f"-msgtype={settings.WATCHED_PROTOCOLS}",
         "-format=json",
+        f"-symbollength={settings.SYMBOL_LENGTH}",
     ]
 
     # Add ID filter if we have a list of IDs to watch

--- a/amr2mqtt/rootfs/amr2mqtt/settings.py
+++ b/amr2mqtt/rootfs/amr2mqtt/settings.py
@@ -53,6 +53,10 @@ MQTT_AVAILABILTY_TOPIC = f"{MQTT_BASE_TOPIC}/bridge/state"
 LAST_SEEN_FORMAT = os.environ.get("LAST_SEEN")
 LAST_SEEN_ENABLED = LAST_SEEN_FORMAT != "disable"
 
+# RTLAMR options
+symbol_length = os.environ.get("SYMBOL_LENGTH")
+SYMBOL_LENGTH = int(symbol_length) if bool(symbol_length) else 72
+
 # Set up logging
 EV_TO_LOG_LEVEL = {
     "DEBUG": logging.DEBUG,

--- a/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
+++ b/amr2mqtt/rootfs/etc/services.d/amr2mqtt/run
@@ -55,6 +55,10 @@ fi
 # --- OTHER SETTINGS ---
 export "LAST_SEEN=$(bashio::config 'last_seen' 'disable')"
 
+if bashio::config.exists 'rtlamr_symbol_length'; then
+    export "SYMBOL_LENGTH=$(bashio::config 'rtlamr_symbol_length')"
+fi
+
 # --- SET LOG LEVEL ---
 case "$(bashio::config 'log_level')" in \
     trace)      ;& \


### PR DESCRIPTION
# Proposed Changes

Add option to set `symbollength` for rtlamr command to help users reduce cpu overhead.

