### PR TITLE
Accept and ignore positional arguments shutdown

### DIFF
--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -82,7 +82,7 @@ ATTRIBUTES = {
 }
 
 
-def shutdown(**_):
+def shutdown(*args, **kwargs):  # pylint: disable=unused-argument
     """Disconnect MQTT client, stop rtlamr and exit."""
     mqttc.publish(
         topic=settings.MQTT_AVAILABILTY_TOPIC,


### PR DESCRIPTION
Fix this error on stop
```
Traceback (most recent call last):
Signal caught, exiting!
  File "/amr2mqtt/amr2mqtt.py", line 388, in main_loop
    amr_line = rtlamr.stdout.readline().strip()
TypeError: shutdown() takes 0 positional arguments but 2 were given
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/amr2mqtt/amr2mqtt.py", line 520, in <module>
    main_loop()
  File "/amr2mqtt/amr2mqtt.py", line 507, in main_loop
    time.sleep(2)
TypeError: shutdown() takes 0 positional arguments but 2 were given
Signal caught, exiting!
```
