### PR TITLE
Publish water as a device class

### DIFF
--- a/amr2mqtt/DOCS.md
+++ b/amr2mqtt/DOCS.md
@@ -160,6 +160,10 @@ multiplier is applied. If omitted, result will not be rounded.
 Type of meter. must be one of the following: `gas`, `water`, or `energy`. Only
 used in discovery messages.
 
+#### Sub-option: `state_class`
+
+Type of state class. Defaults to total. 'Total_increasing' is commonly used for water and gas meters where value would not normally decrease. 
+
 #### Sub-option: `unit_of_measurement`
 
 Unit of measurement for the consumption value. Only used in discovery messages.

--- a/amr2mqtt/config.yaml
+++ b/amr2mqtt/config.yaml
@@ -32,6 +32,7 @@ schema:
       unit_of_measurement: str?
       manufacturer: str?
       model: str?
+      state_class: str?
   mqtt:
     host: str?
     port: port?

--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -210,12 +210,18 @@ def create_interval_sensor(meter_id, meter, device_name, device_id):
 
 def set_consumption_details(payload, meter):
     """Set discovery details for a consumption sensor."""
-    payload["state_class"] = "total"
+    if "state_class" in meter:
+        payload["state_class"] = meter["state"]
+    else: 
+        payload["state_class"] = "total"
+
     if "type" in meter:
         if meter["type"] == "gas":
             payload["device_class"] = "gas"
         elif meter["type"] == "energy":
             payload["device_class"] = "energy"
+        elif meter["type"] == "water":
+            payload["device_class"] = "water"    
         else:
             payload["icon"] = "mdi:water"
 


### PR DESCRIPTION
Added ability to set state_class as total_increasing
added water as a device class that is published to MQTT sensor
updated documentation to include state_class