### PR TITLE
changed water meter payload to set device_class instead of icon

### DIFF
--- a/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
+++ b/amr2mqtt/rootfs/amr2mqtt/amr2mqtt.py
@@ -217,7 +217,7 @@ def set_consumption_details(payload, meter):
         elif meter["type"] == "energy":
             payload["device_class"] = "energy"
         else:
-            payload["icon"] = "mdi:water"
+            payload["device_class"] = "water"
 
     if "unit_of_measurement" in meter:
         payload["unit_of_measurement"] = meter["unit_of_measurement"]


### PR DESCRIPTION
# Proposed Changes

HASS now allows water meters to be integrated into the Energy dashboard *only* if the ``device_class`` is set to ``water``. The icon will default to the appropriate icon.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
